### PR TITLE
Refactor cx types and imports

### DIFF
--- a/cxflow_tensorflow/hooks/decay_lr.py
+++ b/cxflow_tensorflow/hooks/decay_lr.py
@@ -4,11 +4,12 @@ Module with learning rate decaying hook.
 import logging
 
 import tensorflow as tf
-from cxflow.hooks.abstract_hook import AbstractHook
-from cxflow_tensorflow import BaseModel
+import cxflow as cx
+
+from ..model import BaseModel
 
 
-class DecayLR(AbstractHook):
+class DecayLR(cx.AbstractHook):
     """
     Hook for modifying (decaying) the learning rate (or any other variable) during the training.
 

--- a/cxflow_tensorflow/hooks/init_lr.py
+++ b/cxflow_tensorflow/hooks/init_lr.py
@@ -4,11 +4,12 @@ Module with learning rate initializing hook.
 import logging
 
 import tensorflow as tf
-from cxflow.hooks.abstract_hook import AbstractHook
-from cxflow_tensorflow import BaseModel
+import cxflow as cx
+
+from ..model import BaseModel
 
 
-class InitLR(AbstractHook):
+class InitLR(cx.AbstractHook):
     """
     Hook for initializing the learning rate (or any other variable) before the training.
 

--- a/cxflow_tensorflow/hooks/write_tensorboard.py
+++ b/cxflow_tensorflow/hooks/write_tensorboard.py
@@ -5,12 +5,12 @@ import logging
 
 import numpy as np
 import tensorflow as tf
+import cxflow as cx
 
-from cxflow.hooks import AbstractHook
-from cxflow_tensorflow.model import BaseModel
+from ..model import BaseModel
 
 
-class WriteTensorBoard(AbstractHook):
+class WriteTensorBoard(cx.AbstractHook):
     """
     Write scalar epoch variables to TensorBoard summaries.
 
@@ -54,7 +54,7 @@ class WriteTensorBoard(AbstractHook):
         logging.debug('Creating TensorBoard writer')
         self._summary_writer = tf.summary.FileWriter(logdir=output_dir, graph=model.graph, flush_secs=flush_secs)
 
-    def after_epoch(self, epoch_id: int, epoch_data: AbstractHook.EpochData) -> None:
+    def after_epoch(self, epoch_id: int, epoch_data: cx.EpochData) -> None:
         """
         Log the specified epoch data variables to the tensorboard.
 


### PR DESCRIPTION
This PR refactor imports and types. It is adviced to import **cxflow** with 
```
import cxflow as cx
```